### PR TITLE
Correct globwat_links.py

### DIFF
--- a/hydpy/models/globwat/globwat_links.py
+++ b/hydpy/models/globwat/globwat_links.py
@@ -9,7 +9,7 @@ from __future__ import division, print_function
 from hydpy.core import sequencetools
 
 
-class Q(sequencetools.Sequence):
+class Q(sequencetools.LinkSequence):
     """Runoff [m³/s]."""
     NDIM, NUMERIC = 0, False
 


### PR DESCRIPTION
Each individual link sequence must inherit from hydpy.core.sequentools.LinkSequence.  Otherwise methods as "setpointer" won't be available.